### PR TITLE
Fix client crash of await selector

### DIFF
--- a/helper.js
+++ b/helper.js
@@ -127,7 +127,12 @@ const isWhite = data => {
 const refreshCaptcha = async (page, xpath) => {
   let handler = await page.$x(xpath);
   setTimeout(() => {
-    handler[0].click();
+    try {
+      handler[0].click();
+    } catch (error) {
+      console.log('Error, trying again')
+      refreshCaptcha( page, xpath)
+    }
   }, 10);
 };
 
@@ -135,7 +140,7 @@ const clickXPath = async (page, xpath) => {
   let handler = await page.$x(xpath);
   setTimeout(() => {
     handler[0].click();
-  }, 1000);
+  }, 1250);
 };
 
 const removeSponsor = async page => {

--- a/index.js
+++ b/index.js
@@ -22,14 +22,22 @@ const {
   const browser = await puppeteer.launch({
     headless: false,
     defaultViewport: null,
-    args: ["--window-size=200,1000"]
+    args: ["--window-size=200,1000"] 
   });
 
-  const page = await browser.newPage();
+  const [ page ] = await browser.pages();
   await installMouseHelper(page);
   await page.goto(configs.links.globoLoginUrl, {
     waitUntil: "networkidle2"
   });
+
+  try {
+    const visibleInput = await page.waitForSelector('.ng-pristine ng-invalid ng-invalid-required', {visible: true, timeout: 3000 })
+    console.log('Encontrado elemento visivel')
+  } catch (e) {
+    console.log('Não foi possivel encontrar o elemento visivel, output: ', e.message)
+  }
+
   if (process.argv[4] === "login") {
     await page.waitForNavigation();
   }

--- a/index.js
+++ b/index.js
@@ -22,7 +22,7 @@ const {
   const browser = await puppeteer.launch({
     headless: false,
     defaultViewport: null,
-    args: ["--window-size=200,1000"] 
+    args: ["--window-size=200,1000", "--no-sandbox", "--incognito"] 
   });
 
   const [ page ] = await browser.pages();
@@ -31,15 +31,15 @@ const {
     waitUntil: "networkidle2"
   });
 
+  if (process.argv[4] === "login") {
+    await page.waitForNavigation();
+  }
+
   try {
-    const visibleInput = await page.waitForSelector('.ng-pristine ng-invalid ng-invalid-required', {visible: true, timeout: 3000 })
+    const visibleInput = await page.waitForSelector('.ng-invalid', {visible: true, timeout: 1500 })
     console.log('Encontrado elemento visivel')
   } catch (e) {
     console.log('Não foi possivel encontrar o elemento visivel, output: ', e.message)
-  }
-
-  if (process.argv[4] === "login") {
-    await page.waitForNavigation();
   }
 
   await page.type("#login", process.argv[2]);


### PR DESCRIPTION
Sometimes when a client try connect and login, the bot crash, because of the large amount of their ISP connections and differences between latency, so, i added an static class verify for this.