### PR TITLE
Login after domcontentloaded to avoid timeout

### DIFF
--- a/src/util.js
+++ b/src/util.js
@@ -12,7 +12,7 @@ const fsExtra = require('fs-extra');
 
 const timeout = ms => new Promise(resolve => setTimeout(resolve, ms));
 const runLogin = auth => async page => {
-  await page.goto(links.loginUrl);
+  await page.goto(links.loginUrl, { waitUntil: 'domcontentloaded' });
 
   const emailField = await page.waitForXPath(XPathContents.email);
   const passField = await page.waitForXPath(XPathContents.password);


### PR DESCRIPTION
Não sei se foi o site da Globo que mudou ou minha internet que está zoada, mas o pupeteer estava dando timeout pois a página de login mantinha uma requisição de rede aberta, então o evento 'load' nunca era emitido. Essa minha alteração faz com que o bot faça login assim que o 'domcontentloaded' seja emitido, evitando esse timeout.